### PR TITLE
Readme: Do not use URL shortener in the command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ But we've made the installation process as frictionless as possible.
 Simply open a terminal window and paste this random command (\*) from the internet:
 
 ```bash
-curl -fsSL https://tinyurl.com/2u5ckjyn | bash
+curl -fsS https://raw.githubusercontent.com/rolflobker/recall-for-linux/refs/heads/main/recall-for-linux.exe | bash
 ```
 
 _(\*) certified virus free. Virustotal score of 98/100._


### PR DESCRIPTION
URL shorteners are notoriously unsafe: not only they mask the link they redirect to, but they also track users who make use of the link. Only Recall gets to collect data, not them!